### PR TITLE
Add text domain to plugin header

### DIFF
--- a/wp-plugin/bolt-landing/bolt-landing.php
+++ b/wp-plugin/bolt-landing/bolt-landing.php
@@ -4,6 +4,7 @@
  * Description: Embeds the Bolt landing page using a shortcode.
  * Version: 1.0.0
  * Author: Bolt
+ * Text Domain: bolt-landing
  */
 
 // Register shortcode.


### PR DESCRIPTION
## Summary
- add a `Text Domain` field in the WordPress plugin header

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_686d3e3412d0832ea9aed58814530537