### PR TITLE
Use filemtime for asset versioning

### DIFF
--- a/wp-plugin/bolt-landing/bolt-landing.php
+++ b/wp-plugin/bolt-landing/bolt-landing.php
@@ -16,13 +16,13 @@ function bolt_landing_shortcode() {
         'bolt-landing-style',
         $plugin_url . 'dist/assets/index-DHx0o1cY.css',
         array(),
-        null
+        filemtime( plugin_dir_path( __FILE__ ) . 'dist/assets/index-DHx0o1cY.css' )
     );
     wp_enqueue_script(
         'bolt-landing-script',
         $plugin_url . 'dist/assets/index-BC5gZysM.js',
         array(),
-        null,
+        filemtime( plugin_dir_path( __FILE__ ) . 'dist/assets/index-BC5gZysM.js' ),
         true
     );
 


### PR DESCRIPTION
## Summary
- ensure WordPress plugin assets use file modification time for cache busting

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686d3e3321a8832e8f397ef5e625b154